### PR TITLE
Переработка проекта на FastAPI с интеграцией карты

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,61 @@ python cli.py collections samples/points.json cookies.json --collection-name "Д
 ### Примечания
 - UI Яндекс.Карт меняется; селекторы в Playwright подобраны с запасом (несколько вариантов, русские/роле-селекторы).
 - При необходимости используйте `--headless False` для наглядности и скриншотов.
+
+### FastAPI сервер
+
+Запуск сервера:
+```
+uvicorn server:app --host 0.0.0.0 --port 8000
+```
+
+Проверка здоровья:
+```
+GET http://localhost:8000/health
+```
+
+Преобразование точек в GeoJSON:
+```
+POST http://localhost:8000/to-geojson
+Body (json): [
+  {"id":"p1","latitude":55.751244,"longitude":37.618423,"title":"Москва"}
+]
+```
+
+Публикация через Конструктор карт (вернёт публичную ссылку):
+```
+POST http://localhost:8000/publish/constructor
+Body (json): {
+  "title": "Демо точки",
+  "points": [
+    {"id":"p1","latitude":55.751244,"longitude":37.618423,"title":"Москва"}
+  ],
+  "headless": false
+}
+```
+Ответ:
+```
+{"url": "https://yandex.ru/map-..."}
+```
+
+Публикация в Коллекции (нужны cookies авторизованной сессии):
+```
+POST http://localhost:8000/publish/collections
+Body (json): {
+  "cookies_path": "samples/cookies.sample.json",
+  "collection_name": "Демо коллекция",
+  "points": [
+    {"id":"p1","latitude":55.751244,"longitude":37.618423,"title":"Москва"}
+  ],
+  "headless": false
+}
+```
+
+Упрощённые эндпоинты из файлов:
+```
+POST http://localhost:8000/publish/constructor/from-file?path=samples/points.json&title=Демо&headless=false
+POST http://localhost:8000/publish/collections/from-file?points_path=samples/points.json&cookies_path=samples/cookies.sample.json&collection_name=Демо&headless=false
+```
+
+Где взять ссылку для открытия карты?
+- Эндпоинты публикации возвращают поле `url`. Это и есть ссылка, которую можно открыть на любом устройстве и увидеть метки на карте.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ dependencies = [
     "playwright>=1.46.0",
     "typer>=0.12.3",
     "pydantic>=2.8.2",
-    "rich>=13.7.1"
+    "rich>=13.7.1",
+    "fastapi>=0.112.0",
+    "uvicorn>=0.30.0"
 ]
 
 [project.scripts]

--- a/server.py
+++ b/server.py
@@ -1,0 +1,67 @@
+from typing import List, Optional
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from main import Point, points_to_geojson, load_points_from_json
+from automation.constructor import build_map_in_constructor
+from automation.collections import build_collection_in_maps
+
+
+app = FastAPI(title="Yandex Map Publisher")
+
+
+class PublishConstructorRequest(BaseModel):
+    title: str
+    points: List[Point]
+    headless: Optional[bool] = True
+
+
+class PublishCollectionsRequest(BaseModel):
+    cookies_path: str
+    collection_name: str
+    points: List[Point]
+    headless: Optional[bool] = True
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/to-geojson")
+def to_geojson(payload: List[Point]) -> dict:
+    return points_to_geojson(payload)
+
+
+@app.post("/publish/constructor")
+def publish_constructor(body: PublishConstructorRequest) -> dict:
+    url = build_map_in_constructor(points=body.points, map_title=body.title, headless=body.headless)
+    if not url:
+        raise HTTPException(status_code=500, detail="Не удалось получить публичную ссылку из Конструктора")
+    return {"url": url}
+
+
+@app.post("/publish/collections")
+def publish_collections(body: PublishCollectionsRequest) -> dict:
+    url = build_collection_in_maps(points=body.points, cookies_path=body.cookies_path, collection_name=body.collection_name, headless=body.headless)
+    if not url:
+        raise HTTPException(status_code=500, detail="Не удалось получить ссылку коллекции")
+    return {"url": url}
+
+
+@app.post("/publish/constructor/from-file")
+def publish_constructor_from_file(path: str, title: str, headless: bool = True) -> dict:
+    points = load_points_from_json(path)
+    url = build_map_in_constructor(points=points, map_title=title, headless=headless)
+    if not url:
+        raise HTTPException(status_code=500, detail="Не удалось получить публичную ссылку из Конструктора")
+    return {"url": url}
+
+
+@app.post("/publish/collections/from-file")
+def publish_collections_from_file(points_path: str, cookies_path: str, collection_name: str, headless: bool = True) -> dict:
+    points = load_points_from_json(points_path)
+    url = build_collection_in_maps(points=points, cookies_path=cookies_path, collection_name=collection_name, headless=headless)
+    if not url:
+        raise HTTPException(status_code=500, detail="Не удалось получить ссылку коллекции")
+    return {"url": url}
+


### PR DESCRIPTION
Add a FastAPI server to expose map publishing functionality via API endpoints.

This refactors the project to use FastAPI, providing a clear API interface for publishing maps and returning the generated map URL, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-056a8ec6-99ed-4161-b498-e47e4e2eb103">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-056a8ec6-99ed-4161-b498-e47e4e2eb103">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

